### PR TITLE
No more interference from chrome-extensions that utilize postmessages

### DIFF
--- a/chrome/background.js
+++ b/chrome/background.js
@@ -4,6 +4,7 @@ var selectedId = -1;
 
 function refreshCount() {
 	txt = tab_listeners[selectedId] ? tab_listeners[selectedId].length : 0;
+
 	chrome.tabs.get(selectedId, function() {
 		if (!chrome.runtime.lastError) {
 			chrome.browserAction.setBadgeText({"text": ''+txt, tabId: selectedId});

--- a/chrome/popup.js
+++ b/chrome/popup.js
@@ -22,32 +22,36 @@ function listListeners(listeners) {
 	x.parentElement.removeChild(x);
 	x = document.createElement('ol');
 	x.id = 'x';
-	//console.log(listeners);
+
 	document.getElementById('h').innerText = listeners.length ? listeners[0].parent_url : '';
 
 	for(var i = 0; i < listeners.length; i++) {
 		listener = listeners[i]
-		el = document.createElement('li');
 
-		bel = document.createElement('b');
-		bel.innerText = listener.domain + ' ';
-		win = document.createElement('code');
-		win.innerText = ' ' + (listener.window ? listener.window + ' ' : '') + (listener.hops && listener.hops.length ? listener.hops : '');
-		el.appendChild(bel);
-		el.appendChild(win);
+		/* Making sure it's not originating from a chrome-extension */
+		if (! listener.stack.match(/^at\ chrome\-extension\:\/\//)) {
+			el = document.createElement('li');
 
-		sel = document.createElement('span');
-		if(listener.fullstack) sel.setAttribute('title', listener.fullstack.join("\n\n"));
-		seltxt = document.createTextNode(listener.stack);
-		
-		sel.appendChild(seltxt);
-		el.appendChild(sel);
+			bel = document.createElement('b');
+			bel.innerText = listener.domain + ' ';
+			win = document.createElement('code');
+			win.innerText = ' ' + (listener.window ? listener.window + ' ' : '') + (listener.hops && listener.hops.length ? listener.hops : '');
+			el.appendChild(bel);
+			el.appendChild(win);
 
-		pel = document.createElement('pre');
-		pel.innerText = listener.listener;
-		el.appendChild(pel);
+			sel = document.createElement('span');
+			if(listener.fullstack) sel.setAttribute('title', listener.fullstack.join("\n\n"));
+			seltxt = document.createTextNode(listener.stack);
+			
+			sel.appendChild(seltxt);
+			el.appendChild(sel);
 
-		x.appendChild(el);
+			pel = document.createElement('pre');
+			pel.innerText = listener.listener;
+			el.appendChild(pel);
+
+			x.appendChild(el);
+		}
 	}
 	document.getElementById('content').appendChild(x);
 	/*setTimeout(function() {


### PR DESCRIPTION
Hi

I've modified the extension a bit to check if the postmessages are coming from chrome-extensions or not. I'm having Wappalyzer installed and it was interfering with the postmessage extension. This resulted in having arround 5-6 extra logs and stack traces included in every webpage I requested.

**One thing remained unsolved, and that is the little popup that counts all the postmessages it has found from an origin. I'm unsure how to let it only count the ones that are actually included in the extension's popup.**

I thought that this might be helpful to someone else, reason why I'm creating a PR.