### PR TITLE
Ignore Chrome extension postmessages

### DIFF
--- a/chrome/content_script.js
+++ b/chrome/content_script.js
@@ -11,6 +11,10 @@ var injectedJS = function(pushstate, msgeventlistener, msgporteventlistener) {
 	var loaded = false;
     var originalFunctionToString = Function.prototype.toString;
 	var m = function(detail) {
+		// ignore chrome extensions
+		if('stack' in detail && detail.stack.includes("chrome-extension://")){
+			return
+		}
 		var storeEvent = new CustomEvent('postMessageTracker', {'detail':detail});
 		document.dispatchEvent(storeEvent);
 	};


### PR DESCRIPTION
ignores all postMessageTracker events that reference chrome-extension:// in stack